### PR TITLE
Fix the error in print_best_algorithm_code and improve code readability

### DIFF
--- a/see/GeneticSearch.py
+++ b/see/GeneticSearch.py
@@ -25,16 +25,34 @@ def print_best_algorithm_code(individual):
      individual's genetic representation vector."""
     ind_algo = Segmentors.algoFromParams(individual)
     original_function = inspect.getsource(ind_algo.evaluate)
-    print(original_function)
+
+    # Get the body of the function
     function_contents = original_function[original_function.find('        '):\
                             original_function.find('return')]
     while function_contents.find('self.params') != -1:
-        # print(function_contents[function_contents.find('self.params') +
-        #     13:function_contents.find(']')-1])
-        function_contents = function_contents.replace(
-            function_contents[function_contents.find('self.params'):function_contents.find(']')+1],\
-            str(ind_algo.params[function_contents[function_contents.find('self.params') + 13:\
-            function_contents.find(']')-1]]))
+
+        # Find the index of the 's' at the start of self.params
+        params_index = function_contents.find('self.params')
+
+        # Find the index of the ']' at the end of self.params["<SOME_TEXT>"]
+        end_bracket_index = function_contents.find(']', params_index)+1
+
+        # Find the first occurance of self.params["<SOME_TEXT>"] and store it
+        code_to_replace = function_contents[params_index:end_bracket_index]
+
+        # These offset will be used to access only the params_key
+        offset = len('self.params["')
+        offset2 = len('"]')
+
+        # Get the params key
+        params_key = function_contents[params_index + offset:end_bracket_index-offset2]
+
+        # Use the params_key to access the params_value
+        param_value = str(ind_algo.params[params_key])
+
+        # Replace self.params["<SOME_TEXT>"] with the value of self.params["<SOME_TEXT>"]
+        function_contents = function_contents.replace(code_to_replace, param_value)
+
     function_contents = function_contents.replace('        ', '')
     function_contents = function_contents[function_contents.find('\n\"\"\"')+5:]
     print(function_contents)


### PR DESCRIPTION
Resolves issue #6

How it was fixed:
The previous code assumed that the first occurrence of ']' in the file would always immediately follow the first occurrence of "self.params" in the file. However, this is assumption is invalid for some segmenters since they use ']'s for other purposes. Now code looks for the first ']' that occurs after the first occurrence of "self.params" in the file.